### PR TITLE
Upgrade SVNKIT to 1.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
-      <version>1.9.3</version>
+      <version>1.10.1</version>
       <exclusions>
         <exclusion>
           <groupId>com.trilead</groupId>
@@ -173,7 +173,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit-cli</artifactId>
-      <version>1.9.3</version>
+      <version>1.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Reason for that is this plugin does not work on FreeBSD12 

https://svnkit.com/download.php  ( added support only for FreeBSD12-CURRENT hardcoded )
https://issues.tmatesoft.com/issue/SVNKIT-740
https://svn.svnkit.com/repos/svnkit/tags/1.10.1/svnkit/src/main/java/org/tmatesoft/svn/core/internal/wc/SVNFileUtil.java
`final SVNVersion version12 = SVNVersion.parse("12.0-CURRENT");`